### PR TITLE
Use pessimistic version constraint to allow latest pre-release delayed_job

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files        = Dir.glob('spec/**/*')
 
   s.add_runtime_dependency      'activerecord',  '> 2.1.0'
-  s.add_runtime_dependency      'delayed_job',   '3.0.0.pre'
+  s.add_runtime_dependency      'delayed_job',   '~> 3.0.0.pre'
 
   s.add_development_dependency  'rspec',          '~> 2.0'
   s.add_development_dependency  'rake',           '~> 0.8'


### PR DESCRIPTION
Please merge this patch and release version 0.2.1.

Currently, delayed_job_active_record depends on delayed_job 3.0.0.pre therefore we cannot use the latest delayed_job 3.0.0.pre4.

Thanks!
