### PR TITLE
ActiveRecord table_name_prefix

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -1,4 +1,3 @@
-require 'active_record'
 require 'active_record/version'
 module Delayed
   module Backend
@@ -17,8 +16,10 @@ module Delayed
           ::ActiveRecord::VERSION::MAJOR == 3
         end
 
+        delayed_job_table_name = "#{::ActiveRecord::Base.table_name_prefix}delayed_jobs"
+
         if rails3?
-          self.table_name = 'delayed_jobs'
+          self.table_name = delayed_job_table_name
           def self.ready_to_run(worker_name, max_run_time)
             where('(run_at <= ? AND (locked_at IS NULL OR locked_at < ?) OR locked_by = ?) AND failed_at IS NULL', db_time_now, db_time_now - max_run_time, worker_name)
           end
@@ -26,7 +27,7 @@ module Delayed
             order('priority ASC, run_at ASC')
           end
         else
-          set_table_name :delayed_jobs
+          set_table_name delayed_job_table_name
           named_scope :ready_to_run, lambda {|worker_name, max_run_time|
             { :conditions => ['(run_at <= ? AND (locked_at IS NULL OR locked_at < ?) OR locked_by = ?) AND failed_at IS NULL', db_time_now, db_time_now - max_run_time, worker_name] }
           }

--- a/spec/delayed/backend/active_record_spec.rb
+++ b/spec/delayed/backend/active_record_spec.rb
@@ -56,4 +56,23 @@ describe Delayed::Backend::ActiveRecord::Job do
       Delayed::Backend::ActiveRecord::Job.find(job.id).handler.should_not be_blank
     end
   end
+
+  context "ActiveRecord::Base.table_name_prefix" do
+    def reload_job_class_definition
+      # If this can be done in a more sane manner, please fix it
+      load File.join File.dirname(__FILE__), '..', '..', '..', 'lib', 'delayed', 'backend', 'active_record.rb'
+    end
+
+    it "when prefix is not set, should use 'delayed_jobs' as table name" do
+      ::ActiveRecord::Base.table_name_prefix = nil
+      reload_job_class_definition
+      Delayed::Backend::ActiveRecord::Job.table_name.should eq 'delayed_jobs'
+    end
+
+    it "when prefix is set, should prepend it before default table name" do
+      ::ActiveRecord::Base.table_name_prefix = 'custom_'
+      reload_job_class_definition
+      Delayed::Backend::ActiveRecord::Job.table_name.should eq 'custom_delayed_jobs'
+    end
+  end
 end


### PR DESCRIPTION
Setting table name of `Job` class will now honor the `ActiveRecord::Base.table_name_prefix`, since it is appended by migrations. 

Fixes situations where "prefixed_delayed_jobs" table was created by migration, but `Job` is looking for "delayed_jobs" table.
