### PR TITLE
Change to database column type

### DIFF
--- a/lib/generators/delayed_job/templates/migration.rb
+++ b/lib/generators/delayed_job/templates/migration.rb
@@ -1,15 +1,15 @@
 class CreateDelayedJobs < ActiveRecord::Migration
   def self.up
     create_table :delayed_jobs, :force => true do |table|
-      table.integer  :priority, :default => 0      # Allows some jobs to jump to the front of the queue
-      table.integer  :attempts, :default => 0      # Provides for retries, but still fail eventually.
-      table.text     :handler                      # YAML-encoded string of the object that will do work
-      table.text     :last_error                   # reason for last failure (See Note below)
-      table.datetime :run_at                       # When to run. Could be Time.zone.now for immediately, or sometime in the future.
-      table.datetime :locked_at                    # Set when a client is working on this object
-      table.datetime :failed_at                    # Set when all retries have failed (actually, by default, the record is deleted instead)
-      table.string   :locked_by                    # Who is working on this object (if locked)
-      table.string   :queue                        # The name of the queue this job is in
+      table.integer   :priority, :default => 0      # Allows some jobs to jump to the front of the queue
+      table.integer   :attempts, :default => 0      # Provides for retries, but still fail eventually.
+      table.longtext  :handler                      # YAML-encoded string of the object that will do work
+      table.text      :last_error                   # reason for last failure (See Note below)
+      table.datetime  :run_at                       # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime  :locked_at                    # Set when a client is working on this object
+      table.datetime  :failed_at                    # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string    :locked_by                    # Who is working on this object (if locked)
+      table.string    :queue                        # The name of the queue this job is in
       table.timestamps
     end
 


### PR DESCRIPTION
I am submitting this change because when trying to utilize delayed_job with active record to enqueue jobs with a large number of records (approx 100+) the size limit imposed by the column datatype would cause data to be lost during the store.

The change simply changes the column type to longtext from text.
