### PR TITLE
Added not_queues support

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -60,6 +60,7 @@ module Delayed
           scope = scope.scoped(:conditions => ['priority >= ?', Worker.min_priority]) if Worker.min_priority
           scope = scope.scoped(:conditions => ['priority <= ?', Worker.max_priority]) if Worker.max_priority
           scope = scope.scoped(:conditions => ["queue IN (?)", Worker.queues]) if Worker.queues.any?
+          scope = scope.scoped(:conditions => ["queues NOT IN (?)", Worker.not_queues]) if Worker.not_queues.any?
 
           ::ActiveRecord::Base.silence do
             scope.by_priority.all(:limit => limit)


### PR DESCRIPTION
Hello,

I added support for a not_queues option to force the worker to skip over specific queues. I required this functionality so the workers would continue working on jobs with a blank queue, or anything else. Specifically I had jobs that HAD to be run on a sub-set of machines.

I looked for specs (for queue for example) to emulate, but was unable to find any.

Pull coming to DJ master shortly.

--Brian

---

The not_queues option was added to the command via 0e3371e in DJ Master

not_queues allows instructs the worker to NOT work on specified queues
