### PR TITLE
Support for not_queues

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -63,7 +63,7 @@ module Delayed
           scope = scope.scoped(:conditions => ["queue NOT IN (?)", Worker.not_queues]) if Worker.not_queues.any?
 
           ::ActiveRecord::Base.silence do
-            scope.by_priority.all(:limit => limit)
+            scope.by_priority.all(:limit => limit).shuffle
           end
         end
 


### PR DESCRIPTION
Hello,

I added support for a not_queues option to force the worker to skip over specific queues. I required this functionality so the workers would continue working on jobs with a blank queue, or anything else. Specifically I had jobs that HAD to be run on a sub-set of machines.

I looked for specs (for queue for example) to emulate, but was unable to find any.

Pull coming to DJ master shortly.

--Brian
