### PR TITLE
Perf suggestion

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -68,17 +68,19 @@ module Delayed
 
           now = self.db_time_now
 
-          # This works on any database and uses seperate queries to lock and return the job
-          # Databases like PostgreSQL and MySQL that support "SELECT .. FOR UPDATE" (ActiveRecord Pessimistic locking) don't need the second application
-          # of 'readyScope' but it doesn't hurt and it ensures that the job being locked still meets ready_to_run criteria. 
-          count = readyScope.where(:id => nextScope).update_all(:locked_at => now, :locked_by => worker.name)
-          return nil if count == 0
-          return self.where(:locked_at => now, :locked_by => worker.name).first
-
-          # This works on PostgreSQL and uses 1 less query, but uses SQL not supported nativly through ActiveRecord
-          #quotedTableName = ::ActiveRecord::Base.connection.quote_column_name(self.table_name)
-          #reserved = self.find_by_sql(["UPDATE #{quotedTableName} SET locked_at = ?, locked_by = ? WHERE id IN (#{nextScope.to_sql}) RETURNING *",now,worker.name])
-          #return reserved[0]
+          if rails3? && (::ActiveRecord::Base.connection.adapter_name == "PostgreSQL")
+            # This works on PostgreSQL and uses 1 less query, but uses SQL not supported nativly through ActiveRecord
+            quotedTableName = ::ActiveRecord::Base.connection.quote_column_name(self.table_name)
+            reserved = self.find_by_sql(["UPDATE #{quotedTableName} SET locked_at = ?, locked_by = ? WHERE id IN (#{nextScope.to_sql}) RETURNING *",now,worker.name])
+            return reserved[0]
+          else
+            # This works on any database and uses seperate queries to lock and return the job
+            # Databases like PostgreSQL and MySQL that support "SELECT .. FOR UPDATE" (ActiveRecord Pessimistic locking) don't need the second application
+            # of 'readyScope' but it doesn't hurt and it ensures that the job being locked still meets ready_to_run criteria. 
+            count = readyScope.where(:id => nextScope).update_all(:locked_at => now, :locked_by => worker.name)
+            return nil if count == 0
+            return self.where(:locked_at => now, :locked_by => worker.name).first
+          end
         end
 
         # Lock this job for this worker.


### PR DESCRIPTION
Suggestion: Instead of fetching 5 candidates at attempting to lock each one by one, just lock the next job in a single query. Let me know if I'm missing something.

Example of old system and 100 workers (worst but not uncommon case):
1) 100 workers wake up and fetch 5 candidate jobs (they all get the same, or very similar set of 5 jobs), making a total of 100 SELECT calls
2) they all try to lock the first job (only 1 of 99 succeeds). The failing workers try the next, making a total of roughly 500 UPDATE calls
3) a total of 5 jobs get processed from about 600 database calls, and we restart the whole process

New system:
1) 100 workers wake up and fetch the next available job, each getting a single unique job (1 SELECT and 1 UPDATE call each).
2) a total of 100 jobs are processed with exactly 200 SQL calls

I've also included an example to make it all work in 1 call, avoiding an extra round-trip. This requires custom SQL only tested with PostgreSQL
