### PR TITLE
Rails 4 compatibility

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 Gem::Specification.new do |spec|
-  spec.add_dependency   'activerecord', ['>= 2.1.0', '< 4']
+  spec.add_dependency   'activerecord', ['>= 3.0', '< 4.1']
   spec.add_dependency   'delayed_job', '~> 3.0'
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = 'ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke'

--- a/spec/delayed/backend/active_record_spec.rb
+++ b/spec/delayed/backend/active_record_spec.rb
@@ -43,21 +43,6 @@ describe Delayed::Backend::ActiveRecord::Job do
     end
   end
 
-  context "ActiveRecord::Base.send(:attr_accessible, nil)" do
-    before do
-      Delayed::Backend::ActiveRecord::Job.send(:attr_accessible, nil)
-    end
-
-    after do
-      Delayed::Backend::ActiveRecord::Job.send(:attr_accessible, *Delayed::Backend::ActiveRecord::Job.new.attributes.keys)
-    end
-
-    it "is still accessible" do
-      job = Delayed::Backend::ActiveRecord::Job.enqueue :payload_object => EnqueueJobMod.new
-      expect(Delayed::Backend::ActiveRecord::Job.find(job.id).handler).to_not be_blank
-    end
-  end
-
   context "ActiveRecord::Base.table_name_prefix" do
     it "when prefix is not set, use 'delayed_jobs' as table name" do
       ::ActiveRecord::Base.table_name_prefix = nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ class Story < ActiveRecord::Base
   self.primary_key = :story_id
   def tell; text; end
   def whatever(n, _); tell*n; end
-  default_scope where(:scoped => true)
+  default_scope { where(:scoped => true) }
 
   handle_asynchronously :whatever
 end


### PR DESCRIPTION
This PR should allow delayed_job_active_record to run on both Rails 3.x and 4.x, fixing #30. A few of the specific changes are listed below.
- Bumps the activerecord dependency requirement to be 3.0 or higher as delayed_job 3.x does not support activerecord 2.x
- Because of the activerecord 3.0+ requirement change, the scoping done in backend/active_record.rb can be updated to use Rails 3 query methods
- Removes a spec that tested `attr_accessible` which is no longer part of Rails 4

Additionally, this will require collectiveidea/delayed_job#490 to be merged in. I would also figure that after this is merged, the dependency on `delayed_job` in `delayed_job_active_record.gemspec` will need to be bumped to something like `~> 3.1`, assuming the newest `delayed_job` release is tagged at 3.1.

Any comments/suggestions would be great!
