### PR TITLE
Time between when a job is selected and when it is locked can result in a ActiveRecord::RecordNotFound exception

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -55,7 +55,7 @@ module Delayed
               job.save!
             end  
           rescue ::ActiveRecord::RecordNotFound => e
-            warn "Proflem locking Job: #{e.inspect}"
+            warn "Problem locking Job: #{e.inspect}"
             # This can happen if in between the time when we look up the job 
             # and when we try to get the exclusive lock, the job is deleted.  
             # While rare, we should ignore this job and move on to the next one.


### PR DESCRIPTION
I was running in to an issue where my worker was exiting.  Upon investigating, it turned out occasionally, when trying to reserve a job, an `ActiveRecord::RecordNotFound` exception was being thrown in the `reserve` method in `delayed/backend/active_record.rb`.  The problem was a race condition between when we selected the job and when we locked the job.  What was happening was that, on occasion, in between when the worker selected the job and when it tried to lock the job, another worker swooped in and deleted the job.  The result was the ActiveRecord::RecordNotFound error that would halt my worker.

This patch resolves the issue by catching the exception and exiting the reserve method as if the job does not exist.

I have patched both master and 0-4-stable with this issue.
