### PR TITLE
Add back in attr_accessible to delayed ActiveRecord object as otherwise ...

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -9,6 +9,9 @@ module Delayed
 
         scope :by_priority, lambda { order('priority ASC, run_at ASC') }
 
+        attr_accessible :priority, :run_at, :queue, :payload_object,
+                        :failed_at, :locked_at, :locked_by
+
         before_save :set_default_run_at
 
         def self.set_delayed_job_table_name

--- a/spec/delayed/backend/active_record_spec.rb
+++ b/spec/delayed/backend/active_record_spec.rb
@@ -43,6 +43,21 @@ describe Delayed::Backend::ActiveRecord::Job do
     end
   end
 
+  context "ActiveRecord::Base.send(:attr_accessible, nil)" do
+    before do
+      Delayed::Backend::ActiveRecord::Job.send(:attr_accessible, nil)
+    end
+
+    after do
+      Delayed::Backend::ActiveRecord::Job.send(:attr_accessible, *Delayed::Backend::ActiveRecord::Job.new.attributes.keys)
+    end
+
+    it "is still accessible" do
+      job = Delayed::Backend::ActiveRecord::Job.enqueue :payload_object => EnqueueJobMod.new
+      expect(Delayed::Backend::ActiveRecord::Job.find(job.id).handler).to_not be_blank
+    end
+  end
+
   context "ActiveRecord::Base.table_name_prefix" do
     it "when prefix is not set, use 'delayed_jobs' as table name" do
       ::ActiveRecord::Base.table_name_prefix = nil


### PR DESCRIPTION
...delayed_job ActiveRecord::AttributeAssginment::ActiveSupport::concern fails in Rails 3
