### PR TITLE
Fix for issue where failed jobs running repeatedly

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -67,7 +67,7 @@ module Delayed
             # This works on MySQL and possibly some other DBs that support UPDATE...LIMIT. It uses separate queries to lock and return the job
             count = ready_scope.limit(1).update_all(:locked_at => now, :locked_by => worker.name)
             return nil if count == 0
-            self.where(:locked_at => now, :locked_by => worker.name).first
+            self.where(:locked_at => now, :locked_by => worker.name, :failed_at => nil).first
           else
             # This is our old fashion, tried and true, but slower lookup
             ready_scope.limit(worker.read_ahead).detect do |job|


### PR DESCRIPTION
Ran into a bug today that can be reproduced like so:
1. Make a method in a class that simply raises an exception.
2. Queue said method multiple times within the same second with max_attempts = 1.
3. Start your worker.

The first job will be run repeatedly within the same second. This is because of the following code:

``` ruby
count = ready_scope.limit(1).update_all(:locked_at => now, :locked_by => worker.name)
return nil if count == 0
self.where(:locked_at => now, :locked_by => worker.name).first
```

The second query will return the first job even though another job has been locked. Adding `:failed_at => nil` to the where() fixes this.
