### PR TITLE
fix "uninitialized constant ActiveRecord::Generators (NameError)" error

### DIFF
--- a/lib/generators/delayed_job/active_record_generator.rb
+++ b/lib/generators/delayed_job/active_record_generator.rb
@@ -1,6 +1,7 @@
 require 'generators/delayed_job/delayed_job_generator'
 require 'generators/delayed_job/next_migration_version'
 require 'rails/generators/migration'
+require 'rails/generators/active_record'
 
 # Extend the DelayedJobGenerator so that it creates an AR migration
 module DelayedJob


### PR DESCRIPTION
in rails 4, `rails generate delayed_job:active_record` generates this error
