### PR TITLE
Check for MassAssignmentSecurity enabled on ActiveRecord 4

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -7,7 +7,7 @@ module Delayed
       class Job < ::ActiveRecord::Base
         include Delayed::Backend::Base
 
-        if ::ActiveRecord::VERSION::MAJOR < 4 || ::ActiveRecord.constants.include? :MassAssignmentSecurity
+        if ::ActiveRecord::VERSION::MAJOR < 4 || ::ActiveRecord.constants.include?(:MassAssignmentSecurity)
           attr_accessible :priority, :run_at, :queue, :payload_object,
                           :failed_at, :locked_at, :locked_by
         end


### PR DESCRIPTION
ActiveRecord 4 _may_ require setting attr_accessible if the 'protected_attributes' gem is installed. This checks for the MassAssignmentSecurity constant being defined (which the 'protected_attributes' gem defines), and if it finds it, it calls attr_accessible.

Fixes #60.
