### PR TITLE
Adding support for the Teradata adapter, which is similar to the MSSQL adapter.

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -68,7 +68,7 @@ module Delayed
             count = ready_scope.limit(1).update_all(:locked_at => now, :locked_by => worker.name)
             return nil if count == 0
             self.where(:locked_at => now, :locked_by => worker.name, :failed_at => nil).first
-          when "MSSQL"
+          when "MSSQL", "Teradata"
             # The MSSQL driver doesn't generate a limit clause when update_all is called directly
             subsubquery_sql = ready_scope.limit(1).to_sql
             # select("id") doesn't generate a subquery, so force a subquery


### PR DESCRIPTION
I am just adding the adapter for Teradata to the same when clause as the MSSQL adapter as they have the same subquery limitations and the code provided here for MSSQL works for Teradata as well.
