### PR TITLE
update dependencies for activesupport 4.0.0

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,8 +1,9 @@
 # coding: utf-8
 
 Gem::Specification.new do |spec|
-  spec.add_dependency   'activerecord', ['>= 3.0', '< 4.1']
-  spec.add_dependency   'delayed_job',  ['>= 3.0', '< 4.1']
+  spec.add_dependency   'activerecord', ['>= 4.0', '< 4.1']
+  spec.add_dependency   'delayed_job',  ['>= 4.0.0.beta2', '< 4.1']
+  spec.add_runtime_dependency   'protected_attributes'
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = 'ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke'
   spec.email          = ['bryckbost@gmail.com', 'matt@griffinonline.org', 'sferik@gmail.com']

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -1,4 +1,5 @@
 require 'active_record/version'
+require 'protected_attributes'
 module Delayed
   module Backend
     module ActiveRecord
@@ -7,10 +8,8 @@ module Delayed
       class Job < ::ActiveRecord::Base
         include Delayed::Backend::Base
 
-        if ::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity)
-          attr_accessible :priority, :run_at, :queue, :payload_object,
-                          :failed_at, :locked_at, :locked_by, :handler
-        end
+        attr_accessible :priority, :run_at, :queue, :payload_object,
+                        :failed_at, :locked_at, :locked_by, :handler
 
         scope :by_priority, lambda { order('priority ASC, run_at ASC') }
 


### PR DESCRIPTION
I have got a problem when using delayed_job_active_record with Ruby 2.0.0p0 and Rails 4.0.0.
I thought this may happened because of its dependencies are activerecord >= 3.0 and delayed_job >= 3.0 only.
This pull request can make it work with Rails 4.0.0.
