### PR TITLE
Add transaction scope around postgres ‘find_by_sql’ statement

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -61,7 +61,10 @@ module Delayed
             # 'FOR UPDATE' and we would have many locking conflicts
             quoted_table_name = self.connection.quote_table_name(self.table_name)
             subquery_sql      = ready_scope.limit(1).lock(true).select('id').to_sql
-            reserved          = self.find_by_sql(["UPDATE #{quoted_table_name} SET locked_at = ?, locked_by = ? WHERE id IN (#{subquery_sql}) RETURNING *", now, worker.name])
+            reserved = []
+            transaction do 
+              reserved        = self.find_by_sql(["UPDATE #{quoted_table_name} SET locked_at = ?, locked_by = ? WHERE id IN (#{subquery_sql}) RETURNING *", now, worker.name])
+            end
             reserved[0]
           when "MySQL", "Mysql2"
             # This works on MySQL and possibly some other DBs that support UPDATE...LIMIT. It uses separate queries to lock and return the job


### PR DESCRIPTION
This is in order to prevent multiple instances of DJ from picking up the same task (as the current locking of FOR UPDATE will suffice for a single connection, when scaled out our workers seemed to have been picking up the same job on different machines)
