### PR TITLE
Bump activerecord dependency.

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 Gem::Specification.new do |spec|
-  spec.add_dependency   'activerecord', ['>= 3.0', '< 4.1']
+  spec.add_dependency   'activerecord', ['>= 3.0', '< 4.2']
   spec.add_dependency   'delayed_job',  ['>= 3.0', '< 4.1']
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = 'ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke'


### PR DESCRIPTION
We've been running delayed_job_active_record with Rails 4.1.0.rc in production and it worked well. Now that 4.1.0 is out the dependency specs don't match any more.

c.f. https://github.com/collectiveidea/delayed_job/pull/647
