### PR TITLE
fixing the millisecond time precision issue for mysql database>5.6.4

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -66,6 +66,8 @@ module Delayed
             reserved          = find_by_sql(["UPDATE #{quoted_table_name} SET locked_at = ?, locked_by = ? WHERE id IN (#{subquery_sql}) RETURNING *", now, worker.name])
             reserved[0]
           when "MySQL", "Mysql2"
+            #removing the millisecond precision from now(time object),mysql 5.6.4 onwards millisecond precision exists, but the datetime object created doesn't have precision, so discarded while updating. But during the where clause, for mysql(>=5.6.4), it queries with precision as well. So removing the precision
+            now = now.change(:usec => 0)
             # This works on MySQL and possibly some other DBs that support UPDATE...LIMIT. It uses separate queries to lock and return the job
             count = ready_scope.limit(1).update_all(locked_at: now, locked_by: worker.name)
             return nil if count == 0


### PR DESCRIPTION
fixing the millisecond time precision issue for mysql database(>=5.6.4) by stripping the millisecond precision from time object.
The ActiveSupport::Time object for rails 4.2.1b is returning time object with millisecond precision,which is causing the delayed job to not be execute for mysql database.
 The detailed issue and my solution is mentioned in this [issue 95](https://github.com/collectiveidea/delayed_job_active_record/issues/95)
