### PR TITLE
"fair" cpu sharing for jobs of different users, fuzzy worker-queues

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,3 +1,4 @@
+# encoding: utf-8
 Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", [">= 3.0", "< 5.0"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 4.1"]

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -50,9 +50,7 @@ module Delayed
           #ready_scope = ready_scope.where(:queue => Worker.queues) if Worker.queues.any?
           if Worker.queues.any?
             qu = (['queue like ?'] * Worker.queues.size).join(' OR ')
-            args = Worker.queues.collect{|r| "%#{r}%"}
-            ready_scope = ready_scope.where([qu] + args)
-            puts ready_scope.inspect
+            ready_scope = ready_scope.where([qu] + Worker.queues)
           end
           ready_scope = ready_scope.by_priority
 

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -47,7 +47,13 @@ module Delayed
           # scope to filter to the single next eligible job
           ready_scope = ready_scope.where('priority >= ?', Worker.min_priority) if Worker.min_priority
           ready_scope = ready_scope.where('priority <= ?', Worker.max_priority) if Worker.max_priority
-          ready_scope = ready_scope.where(:queue => Worker.queues) if Worker.queues.any?
+          #ready_scope = ready_scope.where(:queue => Worker.queues) if Worker.queues.any?
+          if Worker.queues.any?
+            qu = (['queue like ?'] * Worker.queues.size).join(' OR ')
+            args = Worker.queues.collect{|r| "%#{r}%"}
+            ready_scope = ready_scope.where([qu] + args)
+            puts ready_scope.inspect
+          end
           ready_scope = ready_scope.by_priority
 
           now = self.db_time_now

--- a/lib/generators/delayed_job/templates/migration.rb
+++ b/lib/generators/delayed_job/templates/migration.rb
@@ -10,6 +10,7 @@ class CreateDelayedJobs < ActiveRecord::Migration
       table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
       table.string :locked_by                          # Who is working on this object (if locked)
       table.string :queue                              # The name of the queue this job is in
+      table.string :balance_id                         # E.g. the user_id that "owns" the job, so that user B timly gets a slot, even if user A created thousands jobs before her
       table.timestamps null: true
     end
 


### PR DESCRIPTION
We have different users, for which we do several time-intensive background-jobs, like scaling a large numbers of Images. The standard strategy is "first in, first out", what can be frustration for a user with just 10 Images, uploaded just after an other user with thousands. So I introduced the "balance_id", which can just be set to the user_id for example.

Additionally I let the workers choose the defined queus to work of by mysql-"LIKE '%queue%', so one can easily define a groub of ques for a worker (eg. '_import', which will do image_import and document_import)