### PR TITLE
capability to change table name

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -16,8 +16,8 @@ module Delayed
 
         before_save :set_default_run_at
 
-        def self.set_delayed_job_table_name
-          delayed_job_table_name = "#{::ActiveRecord::Base.table_name_prefix}delayed_jobs"
+        def self.set_delayed_job_table_name(name = 'delayed_jobs')
+          delayed_job_table_name = "#{::ActiveRecord::Base.table_name_prefix}#{name}"
           self.table_name = delayed_job_table_name
         end
 


### PR DESCRIPTION
This is to add a capability to change the hard-coded table name. With this feature, users can configure the table name in the initializer script like:

``` rb
Delayed::Backend::ActiveRecord::Job.set_delayed_job_table_name("my_lazy_jobs")
```
