### PR TITLE
Make delayed_job_active_record a Rails engine

### DIFF
--- a/lib/delayed/backend/active_record/engine.rb
+++ b/lib/delayed/backend/active_record/engine.rb
@@ -1,0 +1,15 @@
+module Delayed
+  module Backend
+    module ActiveRecord
+      class Engine < ::Rails::Engine
+        paths['app/models'] << 'lib'
+
+        initializer 'delayed_job_active_record' do |_app|
+          ActiveSupport.on_load(:active_record) do
+            Delayed::Worker.backend = :active_record
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/delayed_job_active_record.rb
+++ b/lib/delayed_job_active_record.rb
@@ -1,5 +1,10 @@
-require "active_record"
 require "delayed_job"
-require "delayed/backend/active_record"
 
-Delayed::Worker.backend = :active_record
+if defined?(Rails)
+  require "delayed/backend/active_record/engine"
+else
+  require "active_record"
+  require "delayed/backend/active_record"
+
+  Delayed::Worker.backend = :active_record
+end


### PR DESCRIPTION
Explicitly requiring ActiveRecord models may result in losing custom [Active Record configurations](http://guides.rubyonrails.org/configuring.html#configuring-active-record) that are set in `config/initializers` on Rails.

Let's use `Engine.initializer` and `ActiveSupport.on_load` so that `Delayed::Backend::ActiveRecord::Job` will respect arbitrary configs.