### PR TITLE
Add Railtie to delayed_job_active_record

### DIFF
--- a/lib/delayed/backend/active_record/railtie.rb
+++ b/lib/delayed/backend/active_record/railtie.rb
@@ -1,0 +1,14 @@
+module Delayed
+  module Backend
+    module ActiveRecord
+      class Railtie < ::Rails::Railtie
+        initializer 'delayed_job_active_record' do |_app|
+          ActiveSupport.on_load(:active_record) do
+            require "delayed/backend/active_record"
+            Delayed::Worker.backend = :active_record
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/delayed_job_active_record.rb
+++ b/lib/delayed_job_active_record.rb
@@ -1,5 +1,10 @@
-require "active_record"
 require "delayed_job"
-require "delayed/backend/active_record"
 
-Delayed::Worker.backend = :active_record
+if defined?(Rails)
+  require "delayed/backend/active_record/railtie"
+else
+  require "active_record"
+  require "delayed/backend/active_record"
+
+  Delayed::Worker.backend = :active_record
+end


### PR DESCRIPTION
I'm following up on #105.

This changes `delayed_job_active_record` to use `Railtie` and `ActiveSupport.on_load` to set it up on Rails so that `Delayed::Backend::ActiveRecord::Job` will respect arbitrary configs.
