### PR TITLE
Addressing non deterministic behaviour of fetching the next job

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -12,7 +12,7 @@ module Delayed
                           :failed_at, :locked_at, :locked_by, :handler
         end
 
-        scope :by_priority, lambda { order("priority ASC, run_at ASC") }
+        scope :by_priority, lambda { order("priority ASC, run_at ASC, id ASC") }
 
         before_save :set_default_run_at
 


### PR DESCRIPTION
Appending the id field to the order by will resolve the issue because this field is unique, so rows will always be returned in the same order on all machines

#107 