### PR TITLE
Added PostGIS to the available addapters for reserve_with_scope method

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -56,7 +56,7 @@ module Delayed
         def self.reserve_with_scope(ready_scope, worker, now)
           # Optimizations for faster lookups on some common databases
           case connection.adapter_name
-          when "PostgreSQL"
+          when "PostgreSQL", "PostGIS"
             # Custom SQL required for PostgreSQL because postgres does not support UPDATE...LIMIT
             # This locks the single record 'FOR UPDATE' in the subquery
             # http://www.postgresql.org/docs/9.0/static/sql-select.html#SQL-FOR-UPDATE-SHARE


### PR DESCRIPTION
I had problems with jobs getting executed twice (or nr. of running workers times). The problem was that it was using the old way to reserve jobs (which still has this problem and IMO should be removed) because I'm using PostGIS adapter.

Would be nice to pull this in, so I can use the gem again instead of my fork.
