### PR TITLE
Refactor sql statement

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -45,7 +45,7 @@ module Delayed
         set_delayed_job_table_name
 
         def self.ready_to_run(worker_name, max_run_time)
-          where("(run_at <= ? AND (locked_at IS NULL OR locked_at < ?) OR locked_by = ?) AND failed_at IS NULL", db_time_now, db_time_now - max_run_time, worker_name)
+          where("((run_at <= ? AND (locked_at IS NULL OR locked_at < ?)) OR locked_by = ?) AND failed_at IS NULL", db_time_now, db_time_now - max_run_time, worker_name)
         end
 
         def self.before_fork


### PR DESCRIPTION
## Before

`(run_at <= ? AND (locked_at IS NULL OR locked_at < ?) OR locked_by =
?) AND failed_at IS NULL`

This sql statement is really confusing for sql newbie.

## After

`((run_at <= ? AND (locked_at IS NULL OR locked_at < ?)) OR locked_by =
?) AND failed_at IS NULL`

`And` has precedence over `Or`. they are equal.

So this change will not break currently behavior. Just make it more plain for sql newbie.

Reviewed by David Genord and Guihere Cavalcanti