### PR TITLE
Query updates

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -123,10 +123,17 @@ module Delayed
           # Note: active_record would attempt to generate UPDATE...LIMIT like
           # SQL for Postgres if we use a .limit() filter, but it would not
           # use 'FOR UPDATE' and we would have many locking conflicts
-          quoted_name = connection.quote_table_name(table_name)
-          subquery    = ready_scope.limit(1).lock(true).select("id").to_sql
-          sql         = "UPDATE #{quoted_name} SET locked_at = ?, locked_by = ? WHERE id IN (#{subquery}) RETURNING *"
-          reserved    = find_by_sql([sql, now, worker.name])
+          quoted_table_name = connection.quote_table_name(table_name)
+          subquery_sql = ready_scope.limit(1).lock(true).select("id").to_sql
+          sql = <<-SQL.squish
+            WITH sub AS (#{subquery_sql})
+            UPDATE #{quoted_table_name} dj
+            SET locked_at = ?, locked_by = ?
+            FROM sub
+            WHERE dj.id = sub.id
+            RETURNING dj.*
+          SQL
+          reserved = find_by_sql([sql, now, worker.name])
           reserved[0]
         end
 

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -51,10 +51,8 @@ module Delayed
 
         def self.ready_to_run(worker_name, max_run_time)
           where(
-            "(run_at <= ? AND (locked_at IS NULL OR locked_at < ?) OR locked_by = ?) AND failed_at IS NULL",
-            db_time_now,
-            db_time_now - max_run_time,
-            worker_name
+            "failed_at IS NULL AND run_at <= :now AND ((locked_at IS NULL OR locked_at < :timeout) OR locked_by = :name)", # rubocop:disable Metrics/LineLength
+            now: db_time_now, timeout: db_time_now - max_run_time, name: worker_name
           )
         end
 

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -146,9 +146,10 @@ module Delayed
           now = now.change(usec: 0)
           # This works on MySQL and possibly some other DBs that support
           # UPDATE...LIMIT. It uses separate queries to lock and return the job
-          count = ready_scope.limit(1).update_all(locked_at: now, locked_by: worker.name)
+          sets = "locked_at = :now, locked_by = :name, id = (SELECT @dj_update_id := id)"
+          count = ready_scope.limit(1).update_all([sets, now: now, name: worker.name])
           return nil if count == 0
-          where(locked_at: now, locked_by: worker.name, failed_at: nil).first
+          find_by("id = @dj_update_id")
         end
 
         def self.reserve_with_scope_using_optimized_mssql(ready_scope, worker, now)


### PR DESCRIPTION
Use a CTE for the postgres query to avoid a possible limit bug.

Use a user-variable expression in mysql to make the job lookup much faster for big tables.

Make more use of arel for better query quoting and portability