### PR TITLE
Remove force flag from migration

### DIFF
--- a/lib/generators/delayed_job/templates/migration.rb
+++ b/lib/generators/delayed_job/templates/migration.rb
@@ -1,6 +1,6 @@
 class CreateDelayedJobs < ActiveRecord::Migration<%= migration_version %>
   def self.up
-    create_table :delayed_jobs, force: true do |table|
+    create_table :delayed_jobs do |table|
       table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
       table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
       table.text :handler,                 null: false # YAML-encoded string of the object that will do work


### PR DESCRIPTION
This prevents potential destruction of already existent data.