### PR TITLE
Method for improved reloading in Delayed Job

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -71,14 +71,20 @@ module Delayed
           where(locked_by: worker_name).update_all(locked_by: nil, locked_at: nil)
         end
 
-        def self.reserve(worker, max_run_time = Worker.max_run_time)
-          ready_scope =
-            ready_to_run(worker.name, max_run_time)
+        def self.jobs_to_run?(worker, max_run_time = Worker.max_run_time)
+          ready_scope(worker, max_run_time).any?
+        end
+
+        def self.ready_scope(worker, max_run_time)
+          ready_to_run(worker.name, max_run_time)
             .min_priority
             .max_priority
             .for_queues
             .by_priority
+        end
 
+        def self.reserve(worker, max_run_time = Worker.max_run_time)
+          ready_scope = self.ready_scope(worker, max_run_time)
           reserve_with_scope(ready_scope, worker, db_time_now)
         end
 


### PR DESCRIPTION
This relates to the PR on delayed_job: https://github.com/collectiveidea/delayed_job/pull/1022

I've added a `jobs_to_run?` method, that will be used by the delayed_job library. If the method is present, it will use the method to check if it should reload the Rails app.