### PR TITLE
Allow ActiveRecord 5.2

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |spec|
-  spec.add_dependency "activerecord", [">= 3.0", "< 5.2"]
+  spec.add_dependency "activerecord", [">= 3.0", "<= 5.2"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 5"]
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = "ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke"


### PR DESCRIPTION
Version bump to support ActiveRecord 5.2 and therefore Rails 5.2. Specs seem to pass locally on Ruby 2.4.2.