### PR TITLE
Update upper dependency for activerecord

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -149,3 +149,8 @@ Style/FormatStringToken:
 
 Style/NumericPredicate:
   Enabled: false
+
+Naming/FileName:
+  Enabled: true
+  Exclude:
+    - gemfiles/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,15 @@ gemfile: # Supported
   - gemfiles/mysql2/4-2.gemfile
   - gemfiles/mysql2/5-1.gemfile
   - gemfiles/mysql2/5-2.gemfile
+  - gemfiles/mysql2/6-0.gemfile
   - gemfiles/postgresql/4-2.gemfile
   - gemfiles/postgresql/5-1.gemfile
   - gemfiles/postgresql/5-2.gemfile
+  - gemfiles/postgresql/6-0.gemfile
   - gemfiles/sqlite3/4-2.gemfile
   - gemfiles/sqlite3/5-1.gemfile
   - gemfiles/sqlite3/5-2.gemfile
+  - gemfiles/sqlite3/6-0.gemfile
 rvm: # Supported
   - 2.2.10
   - 2.3.7

--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |spec|
-  spec.add_dependency "activerecord", [">= 3.0", "< 5.3"]
+  spec.add_dependency "activerecord", [">= 3.0", "<= 6"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 5"]
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = "ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke"


### PR DESCRIPTION
We are trying to test our application on rails 6.0.0.alpha but we can't install this because of the version lock
Probably this will be helpful that we can try and report any issues with edge rails