### PR TITLE
Fix Postgres UPDATE ... LIMIT bug

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -126,7 +126,7 @@ module Delayed
           # use 'FOR UPDATE' and we would have many locking conflicts
           quoted_name = connection.quote_table_name(table_name)
           subquery    = ready_scope.limit(1).lock(true).select("id").to_sql
-          sql         = "UPDATE #{quoted_name} SET locked_at = ?, locked_by = ? WHERE id IN (#{subquery}) RETURNING *"
+          sql         = "UPDATE #{quoted_name} SET locked_at = ?, locked_by = ? WHERE id = (#{subquery}) RETURNING *"
           reserved    = find_by_sql([sql, now, worker.name])
           reserved[0]
         end


### PR DESCRIPTION
This PR fixes the bug described in #143. 

The subquery returns 1 row so there is no need to use "IN" as the "=" operator will work just fine. Additionally, using "=" doesn't allow the query planner to choose a plan that can sidestep the LIMIT.