### PR TITLE
Fix Rails autoloading

### DIFF
--- a/lib/delayed/backend/active_record/railtie.rb
+++ b/lib/delayed/backend/active_record/railtie.rb
@@ -1,0 +1,14 @@
+module Delayed
+  module Backend
+    module ActiveRecord
+      class Railtie < ::Rails::Railtie
+        initializer 'delayed_job_active_record' do |_app|
+          ActiveSupport.on_load(:active_record) do
+            require "delayed/backend/active_record"
+            Delayed::Worker.backend = :active_record
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/delayed/backend/active_record/railtie.rb
+++ b/lib/delayed/backend/active_record/railtie.rb
@@ -1,12 +1,12 @@
+# frozen_string_literal: true
+
 module Delayed
   module Backend
     module ActiveRecord
       class Railtie < ::Rails::Railtie
-        initializer 'delayed_job_active_record' do |_app|
-          ActiveSupport.on_load(:active_record) do
-            require "delayed/backend/active_record"
-            Delayed::Worker.backend = :active_record
-          end
+        config.after_initialize do
+          require "delayed/backend/active_record"
+          Delayed::Worker.backend = :active_record
         end
       end
     end

--- a/lib/delayed_job_active_record.rb
+++ b/lib/delayed_job_active_record.rb
@@ -2,7 +2,7 @@
 
 require "delayed_job"
 
-if defined?(Rails)
+if defined?(Rails::Railtie)
   require "delayed/backend/active_record/railtie"
 else
   require "active_record"

--- a/lib/delayed_job_active_record.rb
+++ b/lib/delayed_job_active_record.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
-require "active_record"
 require "delayed_job"
-require "delayed/backend/active_record"
 
-Delayed::Worker.backend = :active_record
+if defined?(Rails)
+  require "delayed/backend/active_record/railtie"
+else
+  require "active_record"
+  require "delayed/backend/active_record"
+
+  Delayed::Worker.backend = :active_record
+end


### PR DESCRIPTION
Delay initializing of `backend` until all initializers have run when using Rails.

As mentioned in https://github.com/collectiveidea/delayed_job_active_record/pull/106#issuecomment-336138868  initializing `ActiveRecord` after this gem is loaded prevents problems with `Rails.application.config.active_record.belongs_to_required_by_default`.
But instead of using `on_load(:active_record)` like in #106 this use the `on_load(:after_initialize)` hook. `on_load(:after_initialize)` always runs but after Rails initializes so it won't cause problems with rake tasks.
See: https://guides.rubyonrails.org/engines.html#configuration-hooks

`require "delayed/backend/active_record"` has been removed since it's already called in `Delayed::Worker.Backend=`