### PR TITLE
Fix the build

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ Style/CollectionMethods:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 # Align ends correctly.
 EndAlignment:
   EnforcedStyleAlignWith: variable

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_script:
   - mysql --version
   - psql -c 'create database delayed_job_test;' -U postgres
 script: bundle exec $COMMAND
+services:
+  - mysql
+  - postgresql
 env:
   global:
     - JRUBY_OPTS="$JRUBY_OPTS -Xcli.debug=true --debug"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ rvm: # Supported
   - 2.4.5
   - 2.5.3
   - 2.6.1
-  - jruby-9.1.8.0
+  - jruby-9.2.7.0
 
-jdk: oraclejdk8
+jdk: oraclejdk11
 
 matrix:
   allow_failures:
@@ -41,15 +41,15 @@ matrix:
     # The two combinations below are currently broken. We should stop allowing
     # failure as the issue is resolved. See:
     # https://github.com/jruby/activerecord-jdbc-adapter/issues/700
-    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.2.7.0
       gemfile: gemfiles/mysql2/5-1.gemfile
-    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.2.7.0
       gemfile: gemfiles/postgresql/5-1.gemfile
-    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.2.7.0
       gemfile: gemfiles/mysql2/5-2.gemfile
-    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.2.7.0
       gemfile: gemfiles/postgresql/5-2.gemfile
-    - rvm: jruby-9.1.8.0
+    - rvm: jruby-9.2.7.0
       gemfile: gemfiles/sqlite3/5-2.gemfile
 
   include:

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -170,7 +170,7 @@ module Delayed
           elsif ::ActiveRecord::Base.default_timezone == :utc
             Time.now.utc
           else
-            Time.now # rubocop:disable Rails/TimeZone
+            Time.now
           end
         end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -36,6 +36,17 @@ ActiveRecord::Base.establish_connection config[db_adapter]
 ActiveRecord::Base.logger = Delayed::Worker.logger
 ActiveRecord::Migration.verbose = false
 
+# MySQL 5.7 no longer supports null default values for the primary key
+# Override the default primary key type in Rails <= 4.0
+# https://stackoverflow.com/a/34555109
+if db_adapter == "mysql2" &&
+   (::ActiveRecord::VERSION::MAJOR == 3 ||
+   (::ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 0))
+  class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+    NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+  end
+end
+
 migration_template = File.open("lib/generators/delayed_job/templates/migration.rb")
 
 # need to eval the template with the migration_version intact


### PR DESCRIPTION
The current build fails because of updates in Travis.

1. A newer JDK should be used.
Changes were copied from https://github.com/collectiveidea/delayed_job/pull/1092
2. Travis switched to using Xenial as the default which requires the database services be defined.
https://github.com/travis-ci/travis-ci/issues/6842#issuecomment-502259411
3. Xenial uses mysql 5.7 which requires a fix for a primary key issue for Rails <= 4.0.
4. Some Rubocop cops have changed.