### PR TITLE
psql :optimized_sql strategy now updates a single row

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -131,7 +131,7 @@ module Delayed
           # use 'FOR UPDATE' and we would have many locking conflicts
           quoted_name = connection.quote_table_name(table_name)
           subquery    = ready_scope.limit(1).lock(true).select("id").to_sql
-          sql         = "UPDATE #{quoted_name} SET locked_at = ?, locked_by = ? WHERE id IN (#{subquery}) RETURNING *"
+          sql         = "WITH pending AS (#{subquery}) UPDATE #{quoted_name} SET locked_at = ?, locked_by = ? FROM pending WHERE #{quoted_name}.id = pending.id RETURNING *"
           reserved    = find_by_sql([sql, now, worker.name])
           reserved[0]
         end


### PR DESCRIPTION
This prevents a -single- worker from taking all jobs.

The subquery should a row using `LIMIT 1`. But, it sometimes return multiple rows. Why?
Because the planner may choose to generate a plan that executes a nested loop over the LIMITing subquery, causing more UPDATEs than LIMIT.

The solution is to materialize the selection in a CTE.

fixes https://github.com/collectiveidea/delayed_job/issues/915
fixes #143 

see [detailed explanation](https://koshigoe.github.io/ruby/delayed_job/2017/12/22/why-you-shold-not-use-delayed_job_active_record-with-postgres.html)

credits to @koshigoe and @fsateler.