### PR TITLE
Allow unreleased versions of Rails 7.0

### DIFF
--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.add_dependency "activerecord", [">= 3.0", "< 6.2"]
+  spec.add_dependency "activerecord", [">= 3.0", "< 7.0"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 5"]
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = "ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke"


### PR DESCRIPTION
Rails 6.2 is being skipped in favor of Rails 7. So we shouldn't reference 6.2 in the gemspec.

I copied the implementation from https://github.com/cgriego/active_attr/pull/183 / https://github.com/cgriego/active_attr/commit/25ef02d9fc3702d59696002b0d04a7d1def283c1