### PR TITLE
Rails 7.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0]
+        ruby: ['2.7', '3.0']
         gemfile:
           - gemfiles/mysql2/7-0.gemfile
           - gemfiles/postgresql/7-0.gemfile
@@ -22,17 +22,17 @@ jobs:
           # The future
           #
           # Active Record head
-          - ruby: 2.7
+          - ruby: '2.7'
             gemfile: gemfiles/mysql2/master.gemfile
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/postgresql/master.gemfile
-          - ruby: 2.7
+          - ruby: '2.7'
             gemfile: gemfiles/sqlite3/master.gemfile
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/mysql2/master.gemfile
-          - ruby: 2.7
+          - ruby: '2.7'
             gemfile: gemfiles/postgresql/master.gemfile
-          - ruby: 3.0
+          - ruby: '3.0'
             gemfile: gemfiles/sqlite3/master.gemfile
           # MRI Ruby head
           - ruby: head
@@ -57,23 +57,23 @@ jobs:
           #
           # The current
           #
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: gemfiles/mysql2/6-1.gemfile
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: gemfiles/postgresql/6-1.gemfile
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: gemfiles/sqlite3/6-1.gemfile
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: gemfiles/mysql2/6-1.gemfile
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: gemfiles/postgresql/6-1.gemfile
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: gemfiles/sqlite3/6-1.gemfile
-          - ruby: 2.7
+          - ruby: '2.7'
             gemfile: gemfiles/mysql2/6-1.gemfile
-          - ruby: 2.7
+          - ruby: '2.7'
             gemfile: gemfiles/postgresql/6-1.gemfile
-          - ruby: 2.7
+          - ruby: '2.7'
             gemfile: gemfiles/sqlite3/6-1.gemfile
           - ruby: jruby-9.2
             gemfile: gemfiles/mysql2/6-1.gemfile
@@ -84,9 +84,9 @@ jobs:
           #
           # EOL Active Record
           # Rails 3.2 was maintained longer and is ruby 2.2 compatible
-          - ruby: 2.2
+          - ruby: '2.2'
             gemfile: gemfiles/postgresql/3-2.gemfile
-          - ruby: 2.2
+          - ruby: '2.2'
             gemfile: gemfiles/sqlite3/3-2.gemfile
           # Rails <= 4.0 was only compatible with ruby 2.0
           # The test were running, but there are known incompatibilites
@@ -104,37 +104,37 @@ jobs:
           # - rvm: 2.0.0-p648
           #   gemfile: gemfiles/sqlite3/4-0.gemfile
           # Rails 4.1 was only compatible with ruby 2.1
-          - ruby: 2.1
+          - ruby: '2.1'
             gemfile: gemfiles/postgresql/4-1.gemfile
-          - ruby: 2.1
+          - ruby: '2.1'
             gemfile: gemfiles/sqlite3/4-1.gemfile
           # Rails 4.2 was EOL with the release of 6.0 and compatible with ruby 2.4
-          - ruby: 2.4
+          - ruby: '2.4'
             gemfile: gemfiles/mysql2/4-2.gemfile
-          - ruby: 2.4
+          - ruby: '2.4'
             gemfile: gemfiles/postgresql/4-2.gemfile
-          - ruby: 2.4
+          - ruby: '2.4'
             gemfile: gemfiles/sqlite3/4-2.gemfile
           # Rails 5.0 was EOL with the release of 5.2 and compatible with ruby 2.4
-          - ruby: 2.4
+          - ruby: '2.4'
             gemfile: gemfiles/mysql2/5-0.gemfile
-          - ruby: 2.4
+          - ruby: '2.4'
             gemfile: gemfiles/postgresql/5-0.gemfile
-          - ruby: 2.4
+          - ruby: '2.4'
             gemfile: gemfiles/sqlite3/5-0.gemfile
           # Rails 5.1 was EOL with the release of 6.0 and compatible with ruby 2.5
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: gemfiles/mysql2/5-1.gemfile
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: gemfiles/postgresql/5-1.gemfile
-          - ruby: 2.5
+          - ruby: '2.5'
             gemfile: gemfiles/sqlite3/5-1.gemfile
           # Rails 6.0 was EOL with the release of 7.0 and compatible with ruby 2.6
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: gemfiles/mysql2/6-0.gemfile
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: gemfiles/postgresql/6-0.gemfile
-          - ruby: 2.6
+          - ruby: '2.6'
             gemfile: gemfiles/sqlite3/6-0.gemfile
           - ruby: jruby-9.2
             gemfile: gemfiles/mysql2/6-0.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0']
+        ruby: ['2.7', '3.0', '3.1']
         gemfile:
           - gemfiles/mysql2/7-0.gemfile
           - gemfiles/postgresql/7-0.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,41 +12,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, jruby]
+        ruby: [2.7, 3.0]
         gemfile:
-          - gemfiles/mysql2/5-2.gemfile
-          - gemfiles/postgresql/5-2.gemfile
-          - gemfiles/sqlite3/5-2.gemfile
-          - gemfiles/mysql2/6-0.gemfile
-          - gemfiles/postgresql/6-0.gemfile
-          - gemfiles/sqlite3/6-0.gemfile
-          - gemfiles/mysql2/6-1.gemfile
-          - gemfiles/postgresql/6-1.gemfile
-          - gemfiles/sqlite3/6-1.gemfile
+          - gemfiles/mysql2/7-0.gemfile
+          - gemfiles/postgresql/7-0.gemfile
+          - gemfiles/sqlite3/7-0.gemfile
         include:
           #
           # The future
           #
           # Active Record head
-          - ruby: 2.6
+          - ruby: 2.7
             gemfile: gemfiles/mysql2/master.gemfile
-          - ruby: 2.6
+          - ruby: 3.0
             gemfile: gemfiles/postgresql/master.gemfile
-          - ruby: 2.6
+          - ruby: 2.7
             gemfile: gemfiles/sqlite3/master.gemfile
-          - ruby: 2.7
+          - ruby: 3.0
             gemfile: gemfiles/mysql2/master.gemfile
           - ruby: 2.7
             gemfile: gemfiles/postgresql/master.gemfile
-          - ruby: 2.7
+          - ruby: 3.0
             gemfile: gemfiles/sqlite3/master.gemfile
           # MRI Ruby head
           - ruby: head
-            gemfile: gemfiles/mysql2/6-1.gemfile
+            gemfile: gemfiles/mysql2/master.gemfile
           - ruby: head
-            gemfile: gemfiles/postgresql/6-1.gemfile
+            gemfile: gemfiles/postgresql/master.gemfile
           - ruby: head
-            gemfile: gemfiles/sqlite3/6-1.gemfile
+            gemfile: gemfiles/sqlite3/master.gemfile
+          - ruby: head
+            gemfile: gemfiles/mysql2/7-0.gemfile
+          - ruby: head
+            gemfile: gemfiles/postgresql/7-0.gemfile
+          - ruby: head
+            gemfile: gemfiles/sqlite3/7-0.gemfile
           # JRuby head
           - ruby: jruby-head
             gemfile: gemfiles/mysql2/6-1.gemfile
@@ -54,6 +54,31 @@ jobs:
             gemfile: gemfiles/postgresql/6-1.gemfile
           - ruby: jruby-head
             gemfile: gemfiles/sqlite3/6-1.gemfile
+          #
+          # The current
+          #
+          - ruby: 2.5
+            gemfile: gemfiles/mysql2/6-1.gemfile
+          - ruby: 2.5
+            gemfile: gemfiles/postgresql/6-1.gemfile
+          - ruby: 2.5
+            gemfile: gemfiles/sqlite3/6-1.gemfile
+          - ruby: 2.6
+            gemfile: gemfiles/mysql2/6-1.gemfile
+          - ruby: 2.6
+            gemfile: gemfiles/postgresql/6-1.gemfile
+          - ruby: 2.6
+            gemfile: gemfiles/sqlite3/6-1.gemfile
+          - ruby: 2.7
+            gemfile: gemfiles/mysql2/6-1.gemfile
+          - ruby: 2.7
+            gemfile: gemfiles/postgresql/6-1.gemfile
+          - ruby: 2.7
+            gemfile: gemfiles/sqlite3/6-1.gemfile
+          - ruby: jruby-9.2
+            gemfile: gemfiles/mysql2/6-1.gemfile
+          - ruby: jruby-9.3
+            gemfile: gemfiles/postgresql/6-1.gemfile
           #
           # The past
           #
@@ -104,6 +129,17 @@ jobs:
             gemfile: gemfiles/postgresql/5-1.gemfile
           - ruby: 2.5
             gemfile: gemfiles/sqlite3/5-1.gemfile
+          # Rails 6.0 was EOL with the release of 7.0 and compatible with ruby 2.6
+          - ruby: 2.6
+            gemfile: gemfiles/mysql2/6-0.gemfile
+          - ruby: 2.6
+            gemfile: gemfiles/postgresql/6-0.gemfile
+          - ruby: 2.6
+            gemfile: gemfiles/sqlite3/6-0.gemfile
+          - ruby: jruby-9.2
+            gemfile: gemfiles/mysql2/6-0.gemfile
+          - ruby: jruby-9.3
+            gemfile: gemfiles/postgresql/6-0.gemfile
           #
           # The parallel dimension
           #

--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -3,6 +3,9 @@
 Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", [">= 3.0", "< 7.1"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 5"]
+  spec.metadata = {
+    "rubygems_mfa_required" => "true"
+  }
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = "ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke"
   spec.email          = ["bryckbost@gmail.com", "matt@griffinonline.org", "sferik@gmail.com"]

--- a/delayed_job_active_record.gemspec
+++ b/delayed_job_active_record.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.add_dependency "activerecord", [">= 3.0", "< 6.2"]
+  spec.add_dependency "activerecord", [">= 3.0", "< 7.1"]
   spec.add_dependency "delayed_job",  [">= 3.0", "< 5"]
   spec.authors        = ["Brian Ryckbost", "Matt Griffin", "Erik Michaels-Ober"]
   spec.description    = "ActiveRecord backend for Delayed::Job, originally authored by Tobias Lütke"

--- a/gemfiles/mysql2/7-0.gemfile
+++ b/gemfiles/mysql2/7-0.gemfile
@@ -13,7 +13,7 @@ group :test do
   gem "simplecov", ">= 0.20.0", require: false
   gem "simplecov-lcov", ">= 0.8.0", require: false
 
-  gem "activerecord", "~> 7.0.0.alpha2"
+  gem "activerecord", "~> 7.0.1"
 end
 
 gemspec path: "../../"

--- a/gemfiles/mysql2/7-0.gemfile
+++ b/gemfiles/mysql2/7-0.gemfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rake"
+
+group :test do
+  platforms :ruby, :mswin, :mingw do
+    gem "mysql2", "~> 0.5"
+  end
+
+  gem "rspec", ">= 2.11"
+  gem "simplecov", ">= 0.20.0", require: false
+  gem "simplecov-lcov", ">= 0.8.0", require: false
+
+  gem "activerecord", "~> 7.0.0.alpha2"
+end
+
+gemspec path: "../../"

--- a/gemfiles/postgresql/7-0.gemfile
+++ b/gemfiles/postgresql/7-0.gemfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rake"
+
+group :test do
+  platforms :ruby, :mswin, :mingw do
+    gem "pg", "~> 1.1"
+  end
+
+  gem "rspec", ">= 2.11"
+  gem "simplecov", ">= 0.20.0", require: false
+  gem "simplecov-lcov", ">= 0.8.0", require: false
+
+  gem "activerecord", "~> 7.0.0.alpha2"
+end
+
+gemspec path: "../../"

--- a/gemfiles/postgresql/7-0.gemfile
+++ b/gemfiles/postgresql/7-0.gemfile
@@ -13,7 +13,7 @@ group :test do
   gem "simplecov", ">= 0.20.0", require: false
   gem "simplecov-lcov", ">= 0.8.0", require: false
 
-  gem "activerecord", "~> 7.0.0.alpha2"
+  gem "activerecord", "~> 7.0.1"
 end
 
 gemspec path: "../../"

--- a/gemfiles/sqlite3/7-0.gemfile
+++ b/gemfiles/sqlite3/7-0.gemfile
@@ -13,7 +13,7 @@ group :test do
   gem "simplecov", ">= 0.20.0", require: false
   gem "simplecov-lcov", ">= 0.8.0", require: false
 
-  gem "activerecord", "~> 7.0.0.alpha2"
+  gem "activerecord", "~> 7.0.1"
 end
 
 gemspec path: "../../"

--- a/gemfiles/sqlite3/7-0.gemfile
+++ b/gemfiles/sqlite3/7-0.gemfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rake"
+
+group :test do
+  platforms :ruby, :mswin, :mingw do
+    gem "sqlite3", "~> 1.4"
+  end
+
+  gem "rspec", ">= 2.11"
+  gem "simplecov", ">= 0.20.0", require: false
+  gem "simplecov-lcov", ">= 0.8.0", require: false
+
+  gem "activerecord", "~> 7.0.0.alpha2"
+end
+
+gemspec path: "../../"

--- a/spec/delayed/serialization/active_record_spec.rb
+++ b/spec/delayed/serialization/active_record_spec.rb
@@ -5,13 +5,13 @@ require "helper"
 describe ActiveRecord do
   it "loads classes with non-default primary key" do
     expect do
-      YAML.load(Story.create.to_yaml)
+      YAML.load_dj(Story.create.to_yaml)
     end.not_to raise_error
   end
 
   it "loads classes even if not in default scope" do
     expect do
-      YAML.load(Story.create(scoped: false).to_yaml)
+      YAML.load_dj(Story.create(scoped: false).to_yaml)
     end.not_to raise_error
   end
 end


### PR DESCRIPTION
- Loose dependencies to allow Rails7 to be installed.
- Improved the CI setup to run tests with the latest Ruby and Rails.
    - jruby-head and ruby-2.2, ruby-2.1 with postgres fail, but I don't know how to fix it, so I leave it as it is.
    - fix tests due to Psych >= 4
    - add rubygems_mfa_required rubocop wants in gemspec 
- CI result is [here](https://github.com/willnet/delayed_job_active_record/actions/runs/1706998752)
    - This CI changed delayed_job dependencies to [this branch](https://github.com/collectiveidea/delayed_job/pull/1152) temporarily to build successfully
    - because delayed_job master branch has a dependency with <= Rails 6.1 now
    - so This PR need to be merged after [the PR](https://github.com/collectiveidea/delayed_job/pull/1152) merged.