### PR TITLE
Prevent attempts to write too long error messages

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -183,6 +183,12 @@ module Delayed
           reset
           super
         end
+
+        MAX_LAST_ERROR_LENGTH = (2**16) - 1 # TEXT column can hold up to 2^16 characters
+
+        def last_error=(message)
+          super(message[0...MAX_LAST_ERROR_LENGTH])
+        end
       end
     end
   end


### PR DESCRIPTION
Attempting to write unchecked error messages leads to exceptions with the *mysql2* adapter (something like `ActiveRecord::ValueTooLong: Mysql2::Error: Data too long for column 'last_error'`).

Assigning the error message and persisting the job (when rescheduling it) happens in the exception handler of the `run` method in the worker and is not "guarded" by further exception handers, so any exception raised in this code crashes the worker process. Therefore I think it is worth fixing this even though the fix is maybe a bit ugly...

If you have any other ideas on how to address the issue differently thenI'm all ears and willing to change this PR or contribute a different PR 🙂 

