### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', 'jruby-9.3']
+        ruby: ['2.7', '3.0', '3.1', '3.2', 'jruby-9.3']
         gemfile:
           - gemfiles/mysql2/6-0.gemfile
           - gemfiles/postgresql/6-0.gemfile

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.2
     - name: Generate lockfile for cache key
       run: bundle lock
     - name: Cache gems

--- a/spec/delayed/backend/active_record_spec.rb
+++ b/spec/delayed/backend/active_record_spec.rb
@@ -115,7 +115,7 @@ describe Delayed::Backend::ActiveRecord::Job do
     end
   end
 
-  if ::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity)
+  if ActiveRecord::VERSION::MAJOR < 4 || defined?(ActiveRecord::MassAssignmentSecurity)
     context "ActiveRecord::Base.send(:attr_accessible, nil)" do
       before do
         Delayed::Backend::ActiveRecord::Job.send(:attr_accessible, nil)
@@ -137,19 +137,19 @@ describe Delayed::Backend::ActiveRecord::Job do
 
   context "ActiveRecord::Base.table_name_prefix" do
     it "when prefix is not set, use 'delayed_jobs' as table name" do
-      ::ActiveRecord::Base.table_name_prefix = nil
+      ActiveRecord::Base.table_name_prefix = nil
       Delayed::Backend::ActiveRecord::Job.set_delayed_job_table_name
 
       expect(Delayed::Backend::ActiveRecord::Job.table_name).to eq "delayed_jobs"
     end
 
     it "when prefix is set, prepend it before default table name" do
-      ::ActiveRecord::Base.table_name_prefix = "custom_"
+      ActiveRecord::Base.table_name_prefix = "custom_"
       Delayed::Backend::ActiveRecord::Job.set_delayed_job_table_name
 
       expect(Delayed::Backend::ActiveRecord::Job.table_name).to eq "custom_delayed_jobs"
 
-      ::ActiveRecord::Base.table_name_prefix = nil
+      ActiveRecord::Base.table_name_prefix = nil
       Delayed::Backend::ActiveRecord::Job.set_delayed_job_table_name
     end
   end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -31,10 +31,13 @@ require "delayed/backend/shared_spec"
 Delayed::Worker.logger = Logger.new("/tmp/dj.log")
 ENV["RAILS_ENV"] = "test"
 
-db_adapter = ENV["ADAPTER"]
-gemfile = ENV["BUNDLE_GEMFILE"]
-db_adapter ||= gemfile && gemfile[%r{gemfiles/(.*?)/}] && $1 # rubocop:disable Style/PerlBackrefs
-db_adapter ||= "sqlite3"
+db_adapter = ENV.fetch("ADAPTER") do
+  if %r{gemfiles/(.*?)/} =~ ENV.fetch("BUNDLE_GEMFILE", nil)
+    $1 # rubocop:disable Style/PerlBackrefs
+  else
+    "sqlite3"
+  end
+end
 
 config = YAML.load(File.read("spec/database.yml"))
 ActiveRecord::Base.establish_connection config[db_adapter]


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the CI build matrix and ensure the project is compatible.