### PR TITLE
Do not prematurely load `ActiveRecord::Base`

### DIFF
--- a/lib/delayed_job_active_record.rb
+++ b/lib/delayed_job_active_record.rb
@@ -2,6 +2,9 @@
 
 require "active_record"
 require "delayed_job"
-require "delayed/backend/active_record"
 
-Delayed::Worker.backend = :active_record
+ActiveSupport.on_load(:active_record) do
+  require "delayed/backend/active_record"
+
+  Delayed::Worker.backend = :active_record
+end


### PR DESCRIPTION
While investigating https://github.com/rails/rails/issues/47914, I identified that this gem prematurely loads `ActiveRecord::Base` and so the application is not properly configured at the end.

I detected a similar problem recently with the other gem - https://github.com/ledermann/unread/pull/131. The inners of the problem are described in the comments to the https://github.com/rails/rails/issues/46567. 