### PR TITLE
Deprecation warning Rails 7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ bin
 coverage
 pkg/*
 gemfiles/**/*.gemfile.lock
+.idea/
+.ruby-version

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ bin
 coverage
 pkg/*
 gemfiles/**/*.gemfile.lock
-.idea/
-.ruby-version

--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -62,7 +62,7 @@ module Delayed
         end
 
         def self.before_fork
-          ::ActiveRecord::Base.clear_all_connections!
+          ::ActiveRecord::Base.connection_handler.clear_all_connections!
         end
 
         def self.after_fork


### PR DESCRIPTION
Fixes deprecation warning in active_record.rb
```
 DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_all_connections! is deprecated. 
Please call the method directly on the connection handler; for example: 
`ActiveRecord::Base.connection_handler.clear_all_connections!`. 
(called from before_fork at .rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/bundler/gems/delayed_job_active_record-6e8709f887fa/lib/delayed/backend/active_record.rb:65)
 (ActiveSupport::DeprecationException)
```