### PR TITLE
Optimize mysql query with trilogy gem

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -101,7 +101,7 @@ module Delayed
           case connection.adapter_name
           when "PostgreSQL", "PostGIS"
             reserve_with_scope_using_optimized_postgres(ready_scope, worker, now)
-          when "MySQL", "Mysql2"
+          when "MySQL", "Mysql2", "Trilogy"
             reserve_with_scope_using_optimized_mysql(ready_scope, worker, now)
           when "MSSQL", "Teradata"
             reserve_with_scope_using_optimized_mssql(ready_scope, worker, now)


### PR DESCRIPTION
It optimize mysql query with trilogy gem
fixed #221


-  after fix with trilogy gem (same query with mysql2 gem)
```
Delayed::Backend::ActiveRecord::Job Update All (0.7ms)  UPDATE `delayed_jobs` SET `delayed_jobs`.`locked_at` = '2023-12-11 08:37:43', `delayed_jobs`.`locked_by` = 'host:taketo-mac-mini.local pid:28566' WHERE (((run_at <= '2023-12-11 08:37:43.120067' AND (locked_at IS NULL OR locked_at < '2023-12-11 04:37:43.120069')) OR locked_by = 'host:taketo-mac-mini.local pid:28566') AND failed_at IS NULL) ORDER BY priority ASC, run_at ASC LIMIT 1
```

-  before fix with trilogy gem
```
Delayed::Backend::ActiveRecord::Job Load (0.2ms)  SELECT `delayed_jobs`.`id` FROM `delayed_jobs` WHERE (((run_at <= '2023-12-02 07:44:11.604515' AND (locked_at IS NULL OR locked_at < '2023-12-02 03:44:11.604530')) OR locked_by = 'host:taketo-mac-mini.local pid:6304') AND failed_at IS NULL) ORDER BY priority ASC, run_at ASC LIMIT 5
```
