### PR TITLE
Fix deprecation warning for clear_all_connections!

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -62,7 +62,11 @@ module Delayed
         end
 
         def self.before_fork
-          ::ActiveRecord::Base.connection_handler.clear_all_connections!
+          if ::ActiveRecord.version >= Gem::Version.new('7.1.0')
+            ::ActiveRecord::Base.clear_all_connections!(:all)
+          else
+            ::ActiveRecord::Base.clear_all_connections!
+          end
         end
 
         def self.after_fork


### PR DESCRIPTION
Pass `:all` to `clear_all_connections!` to get rid of this deprecation warning:

https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb#L281-L296