### PR TITLE
Don't use ActiveRecord::Base as parent class

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -28,9 +28,13 @@ module Delayed
         yield(configuration)
       end
 
+      class Base < ::ActiveRecord::Base
+        self.abstract_class = true
+      end
+
       # A job object that is persisted to the database.
       # Contains the work object as a YAML field.
-      class Job < ::ActiveRecord::Base
+      class Job < Base
         include Delayed::Backend::Base
 
         if ::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity)
@@ -46,7 +50,7 @@ module Delayed
         before_save :set_default_run_at
 
         def self.set_delayed_job_table_name
-          delayed_job_table_name = "#{::ActiveRecord::Base.table_name_prefix}delayed_jobs"
+          delayed_job_table_name = "#{Base.table_name_prefix}delayed_jobs"
           self.table_name = delayed_job_table_name
         end
 
@@ -63,14 +67,14 @@ module Delayed
 
         def self.before_fork
           if Gem::Version.new("7.1.0") <= Gem::Version.new(::ActiveRecord::VERSION::STRING)
-            ::ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
+            Base.connection_handler.clear_all_connections!(:all)
           else
-            ::ActiveRecord::Base.connection_handler.clear_all_connections!
+            Base.connection_handler.clear_all_connections!
           end
         end
 
         def self.after_fork
-          ::ActiveRecord::Base.establish_connection
+          Base.establish_connection
         end
 
         # When a worker is exiting, make sure we don't have any locked jobs.
@@ -199,7 +203,7 @@ module Delayed
           if ::ActiveRecord.respond_to?(:default_timezone)
             ::ActiveRecord.default_timezone
           else
-            ::ActiveRecord::Base.default_timezone
+            Base.default_timezone
           end
         end
 

--- a/spec/delayed/backend/active_record_spec.rb
+++ b/spec/delayed/backend/active_record_spec.rb
@@ -6,6 +6,10 @@ require "delayed/backend/active_record"
 describe Delayed::Backend::ActiveRecord::Job do
   it_behaves_like "a delayed_job backend"
 
+  it "is a descendant of Delayed::Backend::ActiveRecord::Base" do
+    expect(described_class).to be < Delayed::Backend::ActiveRecord::Base
+  end
+
   describe "configuration" do
     describe "reserve_sql_strategy" do
       let(:configuration) { Delayed::Backend::ActiveRecord.configuration }


### PR DESCRIPTION
We've been facing performance issues with our delayed jobs table. One of the initiatives we're experimenting on is using a separate database for delayed jobs. Rails supports multiple database connections since version 6.0 using `ActiveRecord::ConnectionHandling#connects_to`.

However, since 6.1, Rails does not allow using `connects_to` in non abstract classes to avoid opening multiple connections to the database. The recommended way to do it is to create a new abstract class and have your models that need a different connection inherit from that new abstract class.

Also, the current version of the delayed job active record backend does not support connection config. The quickest work around  is to make `Delayed::Backend::ActiveRecord::Job` inherit from a new abstract class `Delayed::Backend::ActiveRecord::Base` that can be monkey patched with minimal impact.