### PR TITLE
Fix CI for trilogy & rails 7.0/6.1/6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,16 @@ jobs:
           #   gemfile: gemfiles/postgresql/6-0.gemfile
           # - rvm: rbx-2
           #   gemfile: gemfiles/sqlite3/6-0.gemfile
+        exclude:
+          # not exist activerecord-jdbc-adapter for trilogy
+          - ruby: 'jruby-9.3'
+            gemfile: gemfiles/trilogy/6-0.gemfile
+          - ruby: 'jruby-9.3'
+            gemfile: gemfiles/trilogy/6-1.gemfile
+          - ruby: 'jruby-9.3'
+            gemfile: gemfiles/trilogy/7-0.gemfile
+          - ruby: 'jruby-9.3'
+            gemfile: gemfiles/trilogy/7-1.gemfile
     continue-on-error: ${{ endsWith(matrix.gemfile, 'master.gemfile') || endsWith(matrix.ruby, 'head') }}
     services:
       postgres:

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ Bundler::GemHelper.install_tasks
 
 require "rspec/core/rake_task"
 
-ADAPTERS = %w[mysql2 postgresql sqlite3].freeze
+ADAPTERS = %w[mysql2 trilogy postgresql sqlite3].freeze
 
 ADAPTERS.each do |adapter|
   desc "Run RSpec code examples for #{adapter} adapter"

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -36,6 +36,12 @@ gemfile = ENV.fetch("BUNDLE_GEMFILE", nil)
 db_adapter ||= gemfile && gemfile[%r{gemfiles/(.*?)/}] && $1 # rubocop:disable Style/PerlBackrefs
 db_adapter ||= "sqlite3"
 
+if db_adapter == "trilogy" && ActiveRecord.version < Gem::Version.new("7.1")
+  trilogy_adapter_gem = Gem::Specification.find_by_name("activerecord-trilogy-adapter").gem_dir
+  require "#{trilogy_adapter_gem}/lib/trilogy_adapter/connection"
+  ActiveSupport.on_load(:active_record) { extend TrilogyAdapter::Connection }
+end
+
 config = YAML.load_file("spec/database.yml")
 ActiveRecord::Base.establish_connection config[db_adapter]
 ActiveRecord::Base.logger = Delayed::Worker.logger


### PR DESCRIPTION
It fix CI for trilogy & rails 7.0/6.1/6.0.
When use activerecord-trilogy-adapter gem (rails 7.0/6.1/6.0), manualy load trilogy-adapter at spec/helper.

- Related PR
  - #222