### PR TITLE
Fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -145,7 +145,7 @@ RSpec/NestedGroups:
   Enabled: false
 
 # enforces rules about using `it` or `describe` block methods instead of `feature` or `scenario`
-RSpec/Capybara/FeatureMethods:
+RSpec/Dialect:
   Enabled: false
 
 RSpec/SpecFilePathFormat:

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -10,5 +10,5 @@ Metrics/BlockLength:
 RSpec/ContextWording:
   Enabled: false
 
-RSpec/FilePath:
+Rails/FilePath:
   Enabled: false


### PR DESCRIPTION
It fix ci rubocop error.

### Changes
- replace RSpec/Capybara/FeatureMethods -> RSpec/Dialec
> Error: The `RSpec/Capybara/FeatureMethods` cop has been removed since this cop has migrated to `RSpec/Dialect`. Please use `RSpec/Dialect` instead.

- replace RSpec/FilePath -> Rails/FilePath
> spec/.rubocop.yml: RSpec/FilePath has the wrong namespace - replace it with Rails/FilePath

