### PR TITLE
More test updates

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -19,6 +19,11 @@ jobs:
           - gemfiles/mysql2/master.gemfile
           - gemfiles/sqlite3/master.gemfile
           - gemfiles/trilogy/master.gemfile
+        exclude:
+          - ruby: 'jruby-9.4'
+            gemfile: gemfiles/trilogy/master.gemfile
+          - ruby: 'jruby-head'
+            gemfile: gemfiles/trilogy/master.gemfile
     continue-on-error: true
     services:
       postgres:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,6 +24,20 @@ jobs:
             gemfile: gemfiles/trilogy/master.gemfile
           - ruby: 'jruby-head'
             gemfile: gemfiles/trilogy/master.gemfile
+        include:
+          # jruby with rails 7.1 and 7.2 is still under development with jruby
+          - ruby: jruby-9.4
+            gemfile: gemfiles/mysql2/7-1.gemfile
+          - ruby: jruby-9.4
+            gemfile: gemfiles/postgresql/7-1.gemfile
+          - ruby: jruby-9.4
+            gemfile: gemfiles/sqlite3/7-1.gemfile
+          - ruby: jruby-9.4
+            gemfile: gemfiles/mysql2/7-2.gemfile
+          - ruby: jruby-9.4
+            gemfile: gemfiles/postgresql/7-2.gemfile
+          - ruby: jruby-9.4
+            gemfile: gemfiles/sqlite3/7-2.gemfile
     continue-on-error: true
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.1', '3.2', '3.3', 'jruby-9.4']
+        ruby: ['3.1', '3.2', '3.3']
         gemfile:
           - gemfiles/mysql2/7-1.gemfile
           - gemfiles/postgresql/7-1.gemfile


### PR DESCRIPTION
Trilogy isn't and probably won't be supported on jruby. Removing from canary.

Moving jruby with ActiveReocrd 7.1 and 7.2 to canary until they fix support.