### PR TITLE
Make several additional columns  NOT NULL

### DIFF
--- a/lib/generators/delayed_job/templates/columns_not_null.rb
+++ b/lib/generators/delayed_job/templates/columns_not_null.rb
@@ -1,0 +1,8 @@
+class ColumnsNotNull < ActiveRecord::Migration<%= migration_version %>
+  def change
+    change_column_null :delayed_jobs, :run_at, false
+    change_column_null :delayed_jobs, :queue, false
+    change_column_null :delayed_jobs, :created_at, false
+    change_column_null :delayed_jobs, :updated_at, false
+  end
+end

--- a/lib/generators/delayed_job/templates/migration.rb
+++ b/lib/generators/delayed_job/templates/migration.rb
@@ -5,12 +5,12 @@ class CreateDelayedJobs < ActiveRecord::Migration<%= migration_version %>
       table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
       table.text :handler,                 null: false # YAML-encoded string of the object that will do work
       table.text :last_error                           # reason for last failure (See Note below)
-      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :run_at,              null: false # When to run. Could be Time.zone.now for immediately, or sometime in the future.
       table.datetime :locked_at                        # Set when a client is working on this object
       table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
       table.string :locked_by                          # Who is working on this object (if locked)
-      table.string :queue                              # The name of the queue this job is in
-      table.timestamps null: true
+      table.string :queue,                 null: false # The name of the queue this job is in
+      table.timestamps
     end
 
     add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"

--- a/lib/generators/delayed_job/upgrade_generator.rb
+++ b/lib/generators/delayed_job/upgrade_generator.rb
@@ -14,6 +14,11 @@ module DelayedJob
         "db/migrate/add_queue_to_delayed_jobs.rb",
         migration_version: migration_version
       )
+      migration_template(
+        "columns_not_null.rb",
+        "db/migrate/columns_not_null.rb",
+        migration_version: migration_version
+      )
     end
   end
 end


### PR DESCRIPTION
The following columns are always set by Delayed Jobs and therefore expected to have a value and so can safely be set to be NOT NULL.

- run_at
- queue
- timestamps (created_at, updated_at)

By enforcing these are NOT NULL at the database layer, it improves data integrity by hardening the schema constraints.
