### PR TITLE
Fix a CI failure caused by installing libpg5 in Ruby 2.0 to 2.3 environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
     - name: Reinstall libpg
       if: ${{ matrix.ruby < '2.4' && contains(matrix.gemfile, 'postgresql') }}
       # version located via https://pkgs.org/search/?q=libpq5 and the Ubuntu 20.04 LTS package list
-      run: sudo apt-get update && sudo apt-get install -y --allow-downgrades libpq5=12.19-0ubuntu0.20.04.1 && sudo apt-get install -y --allow-downgrades libpq-dev
+      run: sudo apt-get update && sudo apt-get install -y --allow-downgrades libpq5=12.2-4 && sudo apt-get install -y --allow-downgrades libpq-dev
     - uses: ruby/setup-ruby@v1
       env:
         BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
Fixed an issue where the process to downgrade libpq5 failed in CI for Ruby 2.0 to 2.3 environments.

ref: [Merge pull request #243 from collectiveidea/prepare-4-1-11 · collectiveidea/delayed_job_active_record@e5b4fbf](https://github.com/collectiveidea/delayed_job_active_record/actions/runs/11758646036/job/32757241087)