### PR TITLE
Handle RuboCop warnings

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -38,7 +38,7 @@ module Delayed
                           :failed_at, :locked_at, :locked_by, :handler
         end
 
-        scope :by_priority, lambda { order("priority ASC, run_at ASC") }
+        scope :by_priority, lambda { order(:priority, :run_at) }
         scope :min_priority, lambda { where("priority >= ?", Worker.min_priority) if Worker.min_priority }
         scope :max_priority, lambda { where("priority <= ?", Worker.max_priority) if Worker.max_priority }
         scope :for_queues, lambda { |queues = Worker.queues| where(queue: queues) if Array(queues).any? }


### PR DESCRIPTION
Fix a CI warning about violating the `Rails/OrderArguments` cop by applying autocorrect


```
lib/delayed/backend/active_record.rb:41:44: C: [Corrected] Rails/OrderArguments: Prefer :priority, :run_at instead.
        scope :by_priority, lambda { order("priority ASC, run_at ASC") }
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
```
